### PR TITLE
Customize Mixed Filament Names

### DIFF
--- a/src/libslic3r/MixedFilament.cpp
+++ b/src/libslic3r/MixedFilament.cpp
@@ -320,6 +320,38 @@ static bool use_component_b_advanced_dither(int layer_index, int ratio_a, int ra
     return b_after > b_before;
 }
 
+static std::string percent_encode_name(const std::string &name)
+{
+    std::string out;
+    out.reserve(name.size() + 8);
+    for (unsigned char c : name) {
+        if      (c == '%') { out += "%25"; }
+        else if (c == ',') { out += "%2C"; }
+        else if (c == ';') { out += "%3B"; }
+        else               { out += char(c); }
+    }
+    return out;
+}
+
+static std::string percent_decode_name(const std::string &encoded)
+{
+    std::string out;
+    out.reserve(encoded.size());
+    for (size_t i = 0; i < encoded.size(); ++i) {
+        if (encoded[i] == '%' && i + 2 < encoded.size()) {
+            const char h1 = encoded[i + 1];
+            const char h2 = encoded[i + 2];
+            if      (h1 == '2' && (h2 == 'C' || h2 == 'c')) { out += ','; i += 2; }
+            else if (h1 == '3' && (h2 == 'B' || h2 == 'b')) { out += ';'; i += 2; }
+            else if (h1 == '2' && h2 == '5')                 { out += '%'; i += 2; }
+            else { out += encoded[i]; }
+        } else {
+            out += encoded[i];
+        }
+    }
+    return out;
+}
+
 static bool parse_row_definition(const std::string &row,
                                  unsigned int      &a,
                                  unsigned int      &b,
@@ -333,7 +365,8 @@ static bool parse_row_definition(const std::string &row,
                                  std::string       &gradient_component_weights,
                                  std::string       &manual_pattern,
                                  int               &distribution_mode,
-                                 bool              &deleted)
+                                 bool              &deleted,
+                                 std::string       &custom_name)
 {
     auto trim_copy = [](const std::string &s) {
         size_t lo = 0;
@@ -417,6 +450,7 @@ static bool parse_row_definition(const std::string &row,
     manual_pattern.clear();
     distribution_mode = int(MixedFilament::Simple);
     deleted = false;
+    custom_name.clear();
 
     size_t token_idx = 5;
     if (tokens.size() >= 6) {
@@ -474,6 +508,10 @@ static bool parse_row_definition(const std::string &row,
             uint64_t parsed_stable_id = stable_id;
             if (parse_uint64_token(tok.substr(1), parsed_stable_id))
                 stable_id = parsed_stable_id;
+            continue;
+        }
+        if (tok[0] == 'n' || tok[0] == 'N') {
+            custom_name = percent_decode_name(tok.substr(1));
             continue;
         }
         pattern_tokens.push_back(tok);
@@ -1001,6 +1039,8 @@ std::string MixedFilamentManager::serialize_custom_entries()
            << 'd' << (mf.deleted ? 1 : 0) << ','
            << 'o' << (mf.origin_auto ? 1 : 0) << ','
            << 'u' << mf.stable_id;
+        if (!mf.custom_name.empty())
+            ss << ",n" << percent_encode_name(mf.custom_name);
         const std::string normalized_pattern = normalize_manual_pattern(mf.manual_pattern);
         if (!normalized_pattern.empty())
             ss << ',' << normalized_pattern;
@@ -1069,8 +1109,9 @@ void MixedFilamentManager::load_custom_entries(const std::string &serialized, co
         std::string manual_pattern;
         int distribution_mode = int(MixedFilament::Simple);
         bool deleted = false;
+        std::string custom_name;
         if (!parse_row_definition(row, a, b, stable_id, enabled, custom, origin_auto, mix, pointillism_all_filaments,
-                                  gradient_component_ids, gradient_component_weights, manual_pattern, distribution_mode, deleted)) {
+                                  gradient_component_ids, gradient_component_weights, manual_pattern, distribution_mode, deleted, custom_name)) {
             ++skipped_rows;
             BOOST_LOG_TRIVIAL(warning) << "MixedFilamentManager::load_custom_entries invalid row format: " << row;
             continue;
@@ -1123,6 +1164,7 @@ void MixedFilamentManager::load_custom_entries(const std::string &serialized, co
                 mf.enabled = false;
             mf.custom = false;
             mf.origin_auto = true;
+            mf.custom_name = custom_name;
 
             rebuilt.push_back(std::move(mf));
             consumed_auto_pairs.insert(key);
@@ -1151,6 +1193,7 @@ void MixedFilamentManager::load_custom_entries(const std::string &serialized, co
             mf.enabled = false;
         mf.custom = custom;
         mf.origin_auto = origin_auto;
+        mf.custom_name = custom_name;
         rebuilt.push_back(std::move(mf));
         ++loaded_rows;
     }

--- a/src/libslic3r/MixedFilament.hpp
+++ b/src/libslic3r/MixedFilament.hpp
@@ -77,6 +77,9 @@ struct MixedFilament
     // Computed display colour as "#RRGGBB".
     std::string display_color;
 
+    // Optional user-assigned display name. Empty means auto-generate "Mixed Filament N".
+    std::string custom_name;
+
     bool operator==(const MixedFilament &rhs) const
     {
         return component_a == rhs.component_a &&
@@ -93,7 +96,8 @@ struct MixedFilament
                enabled      == rhs.enabled &&
                deleted      == rhs.deleted &&
                custom       == rhs.custom &&
-               origin_auto  == rhs.origin_auto;
+               origin_auto  == rhs.origin_auto &&
+               custom_name  == rhs.custom_name;
     }
     bool operator!=(const MixedFilament &rhs) const { return !(*this == rhs); }
 };

--- a/src/slic3r/GUI/GUI_Factories.cpp
+++ b/src/slic3r/GUI/GUI_Factories.cpp
@@ -77,6 +77,11 @@ static wxString filament_menu_item_name(const int filament_id_1based, const int 
         return wxString::Format(_L("Filament %d"), filament_id_1based);
     }
 
+    const auto &mixed_mgr = wxGetApp().preset_bundle->mixed_filaments;
+    const Slic3r::MixedFilament *mf = mixed_mgr.mixed_filament_from_id(
+        unsigned(filament_id_1based), size_t(physical));
+    if (mf != nullptr && !mf->custom_name.empty())
+        return wxString::FromUTF8(mf->custom_name.c_str());
     return wxString::Format(_L("Mixed Filament %d"), display_filament_id_1based);
 }
 

--- a/src/slic3r/GUI/GUI_ObjectTable.cpp
+++ b/src/slic3r/GUI/GUI_ObjectTable.cpp
@@ -2839,8 +2839,11 @@ int ObjectTablePanel::init_filaments_and_colors()
                 continue;
             }
 
-            m_filaments_name[i] = wxString::Format("%d: Mixed Filament %d (F%u + F%u)",
-                                                   i + 1, i + 1,
+            const wxString mix_label = mf.custom_name.empty()
+                ? wxString::Format("Mixed Filament %d", i + 1)
+                : wxString::FromUTF8(mf.custom_name.c_str());
+            m_filaments_name[i] = wxString::Format("%d: %s (F%u + F%u)",
+                                                   i + 1, mix_label,
                                                    unsigned(mf.component_a), unsigned(mf.component_b));
             break;
         }

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -4646,7 +4646,10 @@ void Sidebar::update_mixed_filament_panel(bool sync_manager)
         header_sizer->Add(swatch, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, compact_gap_x);
 
         const int virtual_filament_id = int(num_physical + display_mixed_idx + 1);
-        auto *name_label = new wxStaticText(header_panel, wxID_ANY, wxString::Format("Mixed Filament %d", virtual_filament_id));
+        const wxString display_name = mf.custom_name.empty()
+            ? wxString::Format("Mixed Filament %d", virtual_filament_id)
+            : wxString::FromUTF8(mf.custom_name.c_str());
+        auto *name_label = new wxStaticText(header_panel, wxID_ANY, display_name);
         name_label->SetForegroundColour(mixed_text_fg);
         header_sizer->Add(name_label, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, compact_gap_x);
 
@@ -4676,7 +4679,42 @@ void Sidebar::update_mixed_filament_panel(bool sync_manager)
             apply_mixed_entry_changes(mixed_id, updated, false, true);
         });
 
-        auto *del_btn = new ScalableButton(header_panel, wxID_ANY, "cross"); 
+        auto *rename_btn = new ScalableButton(header_panel, wxID_ANY, "rename_edit");
+        rename_btn->SetToolTip(_L("Rename mixed filament"));
+        header_sizer->Add(rename_btn, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, compact_gap_x);
+        rename_btn->Bind(wxEVT_LEFT_UP, [](wxMouseEvent &evt) {
+            evt.StopPropagation();
+            evt.Skip();
+        });
+        rename_btn->Bind(wxEVT_BUTTON, [mixed_id, name_label, virtual_filament_id,
+                                         apply_mixed_entry_changes, preset_bundle,
+                                         header_panel](wxCommandEvent &) {
+            if (!preset_bundle || !name_label)
+                return;
+            auto &mfs = preset_bundle->mixed_filaments.mixed_filaments();
+            if (mixed_id >= mfs.size())
+                return;
+            const wxString current = mfs[mixed_id].custom_name.empty()
+                ? wxString::Format("Mixed Filament %d", virtual_filament_id)
+                : wxString::FromUTF8(mfs[mixed_id].custom_name.c_str());
+            const wxString new_name = wxGetTextFromUser(
+                _L("Enter new name") + ":",
+                _L("Rename Mixed Filament"),
+                current,
+                nullptr);
+            if (new_name.IsEmpty())
+                return;
+            wxString trimmed = new_name.Strip(wxString::both);
+            if (trimmed.IsEmpty())
+                return;
+            MixedFilament updated = mfs[mixed_id];
+            updated.custom_name = trimmed.ToUTF8().data();
+            name_label->SetLabel(trimmed);
+            if (header_panel) header_panel->Layout();
+            apply_mixed_entry_changes(mixed_id, updated, true, false);
+        });
+
+        auto *del_btn = new ScalableButton(header_panel, wxID_ANY, "cross");
         del_btn->SetToolTip(_L("Delete mixed filament"));
         header_sizer->Add(del_btn, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, compact_gap_x);
         


### PR DESCRIPTION
Allow users to rename mixed filaments in the UI.  

### Summary
- Mixed Filaments previously had auto-generated, non-editable names ("Mixed Filament 3", "Mixed Filament 4", etc.). Users can now assign custom display names via a rename button in the sidebar.
- The custom name is a UI alias only — all slicing, tool-change, and virtual-ID logic is unchanged.
- Custom names persist across save/load via a new `n<name>` token in the `mixed_filament_definitions` project config string, with backward-compatible percent-encoding for delimiter characters.

### Backward Compatibility
- Old `*.3mf` files load without issue; custom name defaults to empty and falls back to the auto-generated label.
- The `n` prefix token is new and does not conflict with any existing serialization tokens (`g`, `w`, `m`, `d`, `o`, `u`).

### Reason
- This was in response to the [open issue 74](https://github.com/ratdoux/OrcaSlicer-FullSpectrum/issues/74).
- The build from the workflows downloaded, installed, and allowed me to change the names; but I am not able to test it on my snapmaker until next week.

### Demonstration 
Under the "Mixed Filaments" section, clicking the pen icon will allow users to enter a custom name. This name propagates through the system but not backend code; it is essentially an alias for the UI.
<br>
<img width="415" height="203" alt="mix_fil_color_naming" src="https://github.com/user-attachments/assets/4700f0b4-d645-41e4-91e7-a46e5d60f5ea" />
